### PR TITLE
Fix log tailing for namespaced processes

### DIFF
--- a/public/partials/hosts-listing.ejs
+++ b/public/partials/hosts-listing.ejs
@@ -122,7 +122,7 @@ for (state in sortedstatuses) {
                             }
                         }
                     %>
-                    <a href="/log/<%= host.idHost %>/<%= processes[i].name %>/out" class="btn btn-default"><i class="glyphicon glyphicon-tasks"></i></a>
+                    <a href="/log/<%= host.idHost %>/<%= processFullname %>/out" class="btn btn-default"><i class="glyphicon glyphicon-tasks"></i></a>
                 </td>
             </tr>
         <% } %>


### PR DESCRIPTION
Tailing logs for processes belonging to a process group is currently broken.

I've built on top of @klacointe's work on fixing starting/stopping processes in process groups.

This commit fixes the link to the logs page by prefixing the process name with the group name it belongs to.

This should be merged **after** #23 due to the dependency on `processFullname` variable introduced in that PR.