### PR TITLE
Fixed dependencies for node 4.2.2 and later

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
   },
   "dependencies": {
     "async": "0.9.0",
-    "bcrypt": "0.8.0",
+    "bcrypt": "^0.8.5",
     "connect-session-knex": "0.0.2",
     "ejs": "1.0.0",
     "express": "3.4.4",
     "knex": "0.6.22",
     "mysql": "2.4.2",
-    "sqlite3": "^2.2.7",
+    "sqlite3": "^3.1.1",
     "stylus": "0.47.3",
     "supervisord": "0.0.4"
   }


### PR DESCRIPTION
Fixed issue #25. 

This error is caused by outdated versions of dependencies (namely bcrypt and sqlite3).
Changing the versions fixed the problem. 